### PR TITLE
[FEAT-8] Snackbar 컴포넌트 구현

### DIFF
--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -5,3 +5,4 @@ export { default as MaruIcon } from '@assets/svg/maru.svg?react';
 export { default as SendIcon } from '@assets/svg/send.svg?react';
 export { default as CheckTrueIcon } from '@assets/svg/check-true.svg?react';
 export { default as CheckFalseIcon } from '@assets/svg/check-false.svg?react';
+export { default as WarningIcon } from '@assets/svg/warning.svg?react';

--- a/src/assets/svg/warning.svg
+++ b/src/assets/svg/warning.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" rx="10" fill="#F60000"/>
+<rect x="9" y="4" width="2" height="9" rx="1" fill="white"/>
+<circle cx="10" cy="15" r="1" fill="white"/>
+</svg>

--- a/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet.tsx
@@ -15,11 +15,11 @@ function BottomSheet({ open, onClose, children }: BottomSheetProps) {
     <div
       onTransitionEnd={onTransitionEnd}
       onClick={onClose}
-      className={`animate-fadein absolute inset-0 z-30 bg-black/60 transition-opacity duration-300 ${animationTrigger ? 'opacity-100' : 'opacity-0'}`}
+      className={`absolute inset-0 z-30 bg-black/60 transition-opacity duration-300 ${animationTrigger ? 'opacity-100' : 'opacity-0'}`}
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className={`animate-slideUp absolute bottom-0 z-40 h-80 w-full overflow-y-auto rounded-t-2xl bg-white px-4 py-6 transition-transform duration-300 ${animationTrigger ? 'translate-y-0' : 'translate-y-full'}`}
+        className={`absolute bottom-0 z-40 h-80 w-full overflow-y-auto rounded-t-2xl bg-white px-4 py-6 transition-transform duration-300 ${animationTrigger ? 'translate-y-0' : 'translate-y-full'}`}
       >
         {children}
       </div>

--- a/src/components/snackbar/snackbar.stories.tsx
+++ b/src/components/snackbar/snackbar.stories.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import Header from '@/components/header/header';
+import Layout from '@/components/layout/layout';
+import PresetButton from '@/components/preset-button/preset-button';
+import Snackbar from '@/components/snackbar/snackbar';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Snackbar',
+  component: Snackbar,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    open: {
+      description: '스낵바의 열림 상태',
+    },
+    message: {
+      control: 'text',
+      description: '스낵바에 들어갈 텍스트 메시지',
+    },
+    autoHideDuration: {
+      control: 'number',
+      description: '스낵바가 자동으로 사라지는 시간 ',
+    },
+    position: {
+      control: 'select',
+      description: '스낵바가 나타날 위치. top or bottom 만 존재',
+    },
+    handleClose: {
+      description: '스낵바를 닫을 수 있는 함수',
+    },
+  },
+} satisfies Meta<typeof Snackbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Bottom: Story = {
+  args: {
+    open: false,
+    message: '스낵바 하단 테스트 메시지',
+    autoHideDuration: 3000,
+    position: 'bottom',
+    handleClose: () => {},
+  },
+
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [open, setOpen] = useState(false);
+
+    return (
+      <Layout>
+        <Header />
+        <div className="mt-10 flex justify-center">
+          <PresetButton onClick={() => setOpen(true)}>스낵바 열기</PresetButton>
+        </div>
+        <Snackbar
+          open={open}
+          message="스낵바 하단 테스트 메시지"
+          autoHideDuration={3000}
+          handleClose={() => setOpen(false)}
+          position="bottom"
+        />
+      </Layout>
+    );
+  },
+};
+
+export const Top: Story = {
+  args: {
+    open: false,
+    message: '스낵바 상단 테스트 메시지',
+    autoHideDuration: 3000,
+    position: 'top',
+    handleClose: () => {},
+  },
+
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [open, setOpen] = useState(false);
+
+    return (
+      <Layout>
+        <Header />
+        <div className="mt-10 flex justify-center">
+          <PresetButton onClick={() => setOpen(true)}>스낵바 열기</PresetButton>
+        </div>
+        <Snackbar
+          open={open}
+          message="스낵바 상단 테스트 메시지"
+          autoHideDuration={3000}
+          handleClose={() => setOpen(false)}
+          position="top"
+        />
+      </Layout>
+    );
+  },
+};

--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { WarningIcon } from '@/assets/svg';
+import { useAnimation } from '@/hooks/use-animation.hooks';
+import { cn } from '@/utils/style';
 
 interface SnackbarProps {
   open: boolean;
@@ -9,16 +11,13 @@ interface SnackbarProps {
   position: 'top' | 'bottom';
 }
 
-function Snackbar({ open, handleClose, autoHideDuration, message }: SnackbarProps) {
-  const [isVisible, setIsVisible] = useState(false);
+function Snackbar({ open, handleClose, autoHideDuration, message, position }: SnackbarProps) {
+  const { shouldRender, onTransitionEnd, animationTrigger } = useAnimation(open);
 
   useEffect(() => {
     let timer = null;
-
     if (open) {
-      setIsVisible(true);
       timer = setTimeout(() => {
-        setIsVisible(false);
         setTimeout(() => {
           handleClose();
         }, 200);
@@ -28,16 +27,18 @@ function Snackbar({ open, handleClose, autoHideDuration, message }: SnackbarProp
     return () => {
       if (timer) clearTimeout(timer);
     };
-  }, [open, autoHideDuration, handleClose]);
+  }, [open]);
 
-  if (!open) return null;
+  if (!shouldRender) return null;
 
   return (
-    <div className="absolute bottom-24 flex w-full justify-center">
+    <div className={cn('absolute z-20 flex w-full justify-center', position === 'bottom' ? 'bottom-24' : 'top-5')}>
       <div
-        className={`flex gap-3 rounded-3xl bg-slate-800 px-8 py-4 text-headline text-white transition-all duration-200 ${
-          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
-        } `}
+        onTransitionEnd={onTransitionEnd}
+        className={cn(
+          'flex gap-3 rounded-3xl bg-slate-800 px-8 py-4 text-headline text-white transition-all duration-200',
+          animationTrigger ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0',
+        )}
       >
         <WarningIcon />
         <span>{message}</span>

--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { WarningIcon } from '@/assets/svg';
+
+interface SnackbarProps {
+  open: boolean;
+  handleClose: () => void;
+  autoHideDuration: number;
+  message: string;
+  position: 'top' | 'bottom';
+}
+
+function Snackbar({ open, handleClose, autoHideDuration, message }: SnackbarProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    let timer = null;
+
+    if (open) {
+      setIsVisible(true);
+      timer = setTimeout(() => {
+        setIsVisible(false);
+        setTimeout(() => {
+          handleClose();
+        }, 200);
+      }, autoHideDuration);
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [open, autoHideDuration, handleClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="absolute bottom-24 flex w-full justify-center">
+      <div
+        className={`flex gap-3 rounded-3xl bg-slate-800 px-8 py-4 text-headline text-white transition-all duration-200 ${
+          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+        } `}
+      >
+        <WarningIcon />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}
+
+export default Snackbar;

--- a/src/hooks/use-animation.hooks.ts
+++ b/src/hooks/use-animation.hooks.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 export function useAnimation(condition: boolean) {
-  const [shouldRender, setShouldRender] = useState(condition);
   const [isComplete, setIsComplete] = useState(false);
 
   useEffect(() => {
@@ -11,14 +10,12 @@ export function useAnimation(condition: boolean) {
   const onTransitionEnd = () => {
     if (!condition) setIsComplete(false);
   };
-
-  useEffect(() => {
-    setShouldRender(condition || isComplete);
-  }, [condition, isComplete]);
+  const shouldRender = condition || isComplete;
+  const animationTrigger = condition && isComplete;
 
   return {
     shouldRender,
     onTransitionEnd,
-    animationTrigger: condition,
+    animationTrigger,
   };
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,46 +21,6 @@ module.exports = {
       fontFamily: {
         sans: ['Pretendard', 'sans-serif'],
       },
-      keyframes: {
-        fadein: {
-          '0%': {
-            opacity: '0',
-          },
-          '100%': {
-            opacity: '1',
-          },
-        },
-        fadeout: {
-          '0%': {
-            opacity: '1',
-          },
-          '100%': {
-            opacity: '0',
-          },
-        },
-        slideUp: {
-          '0%': {
-            transform: 'translateY(100%)',
-          },
-          '100%': {
-            transform: 'translateY(0)',
-          },
-        },
-        slideDown: {
-          '0%': {
-            transform: 'translateY(0)',
-          },
-          '100%': {
-            transform: 'translateY(100%)',
-          },
-        },
-      },
-      animation: {
-        fadein: 'fadein 0.25s',
-        fadeout: 'fadeout 0.25s',
-        slideUp: 'slideUp 0.25s ease-out',
-        slideDown: 'slideDown 0.25s ease-out',
-      },
     },
   },
 };


### PR DESCRIPTION
## 📝 PR 내용
- Snackbar 컴포넌트와 스토리 북 구현했습니다

## ✅ 작업 내용
- 현재 스낵바 컴포넌트는 Top과 Bottom 포지션만 존재하며 추후 다른 포지션이 추가되면 수정하겠습니다
- 기존 useAnimation 훅에서 상태 관리를 잘못하고 있어 해당 부분 수정하였습니다
  - 컴포넌트 첫 렌더링 시 transition이 발생되지 않는 버그가 존재하여 keyframe 애니메이션을 사용하였지만 수정 후 transition이 옳바르게 작동하여 애니메이션 삭제했습니다.

## 📸 스크린 샷 / 영상 (선택)
- 스토리북 참고 부탁드립니다

## 🤔 고민 했던 부분 (선택)

<!-- 작업 중 고민했던 부분과 해결 방법을 공유해주세요 -->
- 현재 디자인 상 Snackbar의 종류가 Warning 만 존재하여 추후 확장성에 따로 신경을 쓰지 않았습니다. 혹시 Snackbar의 종류가 Warning외에 다른 종류가 추가될 가능성이 있다면 해당 부분도 props로 전달 받는게 좋을거 같다는 생각이 듭니다. 혹시 Snackbar의 종류가 추가될 가능성이 있을까요 ?

## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #8
