### PR TITLE
[FEAT-4] 전형 상세 선택지 가로 드래깅 구현 

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,7 +1,7 @@
 function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-dvh items-center justify-center bg-[#EEEE]">
-      <div className="mobile:h-full mobile:min-h-[480px] mobile:min-w-[320px] mobile:rounded-none desktop:h-[780px] desktop:max-w-[390px] desktop:rounded-3xl desktop:border desktop:border-gray-200 desktop:shadow-2xl relative flex h-full w-full flex-col overflow-hidden border bg-[#E7E7E7]">
+      <div className="relative flex h-full w-full flex-col overflow-hidden border bg-[#E7E7E7] mobile:h-full mobile:min-h-[480px] mobile:min-w-[320px] mobile:rounded-none desktop:h-[780px] desktop:max-w-[390px] desktop:rounded-3xl desktop:border desktop:border-gray-200 desktop:shadow-2xl">
         {children}
       </div>
     </div>

--- a/src/hooks/use-draggable.ts
+++ b/src/hooks/use-draggable.ts
@@ -24,7 +24,6 @@ export function useDraggable(scrollRef: RefObject<HTMLDivElement | null>) {
       setTotalX(x + scrollRef.current.scrollLeft);
     }
 
-    // 애니메이션이 진행 중이라면 중단
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
     }
@@ -41,7 +40,7 @@ export function useDraggable(scrollRef: RefObject<HTMLDivElement | null>) {
 
     if (deltaTime > 0) {
       const deltaX = currentX - lastMouseXRef.current;
-      velocityRef.current = deltaX / deltaTime; // pixels per millisecond
+      velocityRef.current = deltaX / deltaTime;
     }
 
     lastMouseXRef.current = currentX;
@@ -56,15 +55,14 @@ export function useDraggable(scrollRef: RefObject<HTMLDivElement | null>) {
   const applyMomentum = useCallback(() => {
     if (!scrollRef.current) return;
 
-    const deceleration = 0.95; // 감속 계수 (0.95 = 95%의 속도 유지)
-    const stopThreshold = 0.01; // 이 속도 이하면 애니메이션 중단
+    const deceleration = 0.95;
+    const stopThreshold = 0.01;
 
     const animate = () => {
       if (!scrollRef.current) return;
 
       velocityRef.current *= deceleration;
 
-      // velocity를 스크롤에 적용 (deltaTime = 16ms 가정)
       scrollRef.current.scrollLeft -= velocityRef.current * 16;
 
       if (Math.abs(velocityRef.current) > stopThreshold) {
@@ -82,13 +80,11 @@ export function useDraggable(scrollRef: RefObject<HTMLDivElement | null>) {
     e.stopPropagation();
     setIsDragging(false);
 
-    // 마우스를 빠르게 움직였을 때만 관성 적용
     if (Math.abs(velocityRef.current) > 0.1) {
       applyMomentum();
     }
   };
 
-  // 컴포넌트 언마운트 시 진행 중인 애니메이션 정리
   useEffect(() => {
     return () => {
       if (animationFrameRef.current) {

--- a/src/hooks/use-draggable.ts
+++ b/src/hooks/use-draggable.ts
@@ -1,0 +1,106 @@
+import { RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import throttle from '@/utils/throttle';
+
+export function useDraggable(scrollRef: RefObject<HTMLDivElement | null>) {
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+
+  const [totalX, setTotalX] = useState(0);
+  const velocityRef = useRef<number>(0);
+  const lastMouseXRef = useRef<number>(0);
+  const lastTimestampRef = useRef<number>(0);
+  const animationFrameRef = useRef<number>();
+
+  const onDragStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+    const x = e.clientX;
+    lastMouseXRef.current = x;
+    lastTimestampRef.current = Date.now();
+    velocityRef.current = 0;
+
+    if (scrollRef.current && 'scrollLeft' in scrollRef.current) {
+      setTotalX(x + scrollRef.current.scrollLeft);
+    }
+
+    // 애니메이션이 진행 중이라면 중단
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+  };
+
+  const onDragMove = throttle((e: React.MouseEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    const currentX = e.clientX;
+    const currentTimestamp = Date.now();
+    const deltaTime = currentTimestamp - lastTimestampRef.current;
+
+    if (deltaTime > 0) {
+      const deltaX = currentX - lastMouseXRef.current;
+      velocityRef.current = deltaX / deltaTime; // pixels per millisecond
+    }
+
+    lastMouseXRef.current = currentX;
+    lastTimestampRef.current = currentTimestamp;
+
+    const scrollLeft = totalX - currentX;
+    if (scrollRef.current && 'scrollLeft' in scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollLeft;
+    }
+  }, 10);
+
+  const applyMomentum = useCallback(() => {
+    if (!scrollRef.current) return;
+
+    const deceleration = 0.95; // 감속 계수 (0.95 = 95%의 속도 유지)
+    const stopThreshold = 0.01; // 이 속도 이하면 애니메이션 중단
+
+    const animate = () => {
+      if (!scrollRef.current) return;
+
+      velocityRef.current *= deceleration;
+
+      // velocity를 스크롤에 적용 (deltaTime = 16ms 가정)
+      scrollRef.current.scrollLeft -= velocityRef.current * 16;
+
+      if (Math.abs(velocityRef.current) > stopThreshold) {
+        animationFrameRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    animate();
+  }, []);
+
+  const onDragEnd = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    if (!scrollRef.current) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    // 마우스를 빠르게 움직였을 때만 관성 적용
+    if (Math.abs(velocityRef.current) > 0.1) {
+      applyMomentum();
+    }
+  };
+
+  // 컴포넌트 언마운트 시 진행 중인 애니메이션 정리
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    onMouseDown: onDragStart,
+    onMouseMove: onDragMove,
+    onMouseUp: onDragEnd,
+    onMouseLeave: onDragEnd,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,16 @@
 .bg-image-tree-right {
   @apply bg-[url('./assets/svg/tree.svg')] bg-contain bg-right bg-no-repeat;
 }
+
+@layer utilities {
+  .scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scrollbar::-webkit-scrollbar-thumb {
+    background: rgb(209, 209, 209);
+    border: 1px solid rgb(209, 209, 209); /* 배경색과 같은 색상의 보더 */
+    border-radius: 100px;
+  }
+}

--- a/src/page/components/chat-step/choose-admission-category/choose-admission-category.tsx
+++ b/src/page/components/chat-step/choose-admission-category/choose-admission-category.tsx
@@ -3,6 +3,7 @@ import TextMenu from '@/components/menu-items/text-menu/text-menu';
 import MenuList from '@/components/menu-list/menu-list';
 import systemMessage from '@/constants/message';
 import useAdmissionDetail from '@/hooks/querys/useAdmissionDetail';
+import DraggableScroller from '@/page/components/chat-step/choose-admission-category/draggable-scroller';
 import useAdmissionStore from '@/stores/store/admission-store';
 import useMessagesStore from '@/stores/store/message-store';
 import { ADDMISSION, AdmissionType } from '@/types/admission-type';
@@ -18,6 +19,7 @@ function ChooseAdmissionCategory({ admissionType, changeStep }: Props) {
   const { setMessages } = useMessagesStore();
   const { setAdmissionCategory } = useAdmissionStore();
   const data = useAdmissionDetail(admissionType);
+
   const selectCategory = (category: string) => {
     changeStep('상세전형 선택 결과');
     setMessages([
@@ -47,7 +49,7 @@ function ChooseAdmissionCategory({ admissionType, changeStep }: Props) {
   return (
     <div>
       <div className="mt-2">
-        <div className="flex w-80 cursor-grab flex-nowrap items-start gap-5 overflow-x-auto">
+        <DraggableScroller>
           {data.map((option) => (
             <MenuList key={option.label}>
               <MenuList.Title title={`${option.label}전형`} />
@@ -56,7 +58,7 @@ function ChooseAdmissionCategory({ admissionType, changeStep }: Props) {
               ))}
             </MenuList>
           ))}
-        </div>
+        </DraggableScroller>
       </div>
     </div>
   );

--- a/src/page/components/chat-step/choose-admission-category/draggable-scroller.tsx
+++ b/src/page/components/chat-step/choose-admission-category/draggable-scroller.tsx
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+import { useDraggable } from '@/hooks/use-draggable';
+
+function DraggableScroller({ children }: { children: React.ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const events = useDraggable(scrollRef);
+
+  return (
+    <div
+      ref={scrollRef}
+      className="scrollbar flex w-80 cursor-grab select-none flex-nowrap items-start gap-5 overflow-x-auto"
+      {...events}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default DraggableScroller;

--- a/src/page/components/main/main.tsx
+++ b/src/page/components/main/main.tsx
@@ -28,7 +28,7 @@ function Main() {
 
   return (
     <>
-      <main className="flex h-full flex-col gap-6 overflow-y-auto overflow-x-hidden">
+      <main className="scrollbar flex h-full flex-col gap-6 overflow-y-auto overflow-x-hidden">
         <div className="flex-1 py-6 pl-12 pr-3">
           <MessageHistory />
           <Funnel step={steps}>

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function throttle<T extends (...args: any[]) => void>(callback: T, delay: number) {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timerId) return;
+
+    timerId = setTimeout(() => {
+      callback(...args);
+      timerId = null;
+    }, delay);
+  };
+}
+
+export default throttle;


### PR DESCRIPTION
## 📝 PR 내용

수시,정시, 편입 상세 전형 중 수시, 정시 상세 전형 선택에 PC 에서도 모바일과 동일한 사용자 경험을 주도록 드래깅 스크롤이 가능하도록 구현하였습니다

## ✅ 작업 내용

`DraggableScroller`  컴포넌트를 통해 기존 메뉴 컴포넌트들을 감싸면 드래깅을 통해 스크롤이 가능합니다

```jsx
<DraggableScroller>
          {data.map((option) => (
            <MenuList key={option.label}>
              <MenuList.Title title={`${option.label}전형`} />
              {option.children.map((menu) => (
                <TextMenu label={menu} key={menu} onClick={() => selectCategory(menu)} />
              ))}
            </MenuList>
          ))}
 </DraggableScroller>
```

현재 위와 같이 사용하고 있습니다

`useDraggable`  커스텀 훅을 통해 드래깅에 필요한 이벤트 리스너 함수들과 상태들을 분리했습니다.

## 📸 스크린 샷 / 영상 (선택
![드래기 적용 후](https://github.com/user-attachments/assets/e44626a7-8af5-4b87-9137-817cc8fd1720)


## 🤔 고민 했던 부분 (선택)

- 문제: 드래깅 스크롤 구현 후 드래깅이 모바일 환경과 달리 툭툭 끊기는 듯한 경험이 있었습니다
- 해결: 모바일 스크롤에는 관성을 적용하여 부드러운 사용자 경험을 준다는 사실을 확인하고 동일한 사용자 경험을 위해 관성 스크롤을 적용해보았습니다.
    
    **자세한 해결 경험 및 코드 설명은 저희 노션 트러블 슈팅 문서에 작성해 두었으니 꼭 참고 부탁드립니다!**
    

## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #4