### PR TITLE
[FEAT-25] 수시,정시,편입 카테고리 활성화 상태 기능 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,10 +1,15 @@
 import { server_axiosInstance } from '@/api';
-import { AdmissionType, ResponseDetailAdmissionType } from '@/types/admission-type';
+import { AdmissionType, isActiveAdmissionType, ResponseDetailAdmissionType } from '@/types/admission-type';
 import { ResponseCollegeType, ResponseDepartmentType } from '@/types/department';
 import { DefaultPostQuestionParams, PostQuestionResponse } from '@/types/questions';
 
 export const getAdmissionDetail = async (type: AdmissionType): Promise<ResponseDetailAdmissionType[]> => {
   const response = await server_axiosInstance.get(`/api/admissions/details/${type}`);
+  return response.data;
+};
+
+export const getAdmissionStatus = async (): Promise<isActiveAdmissionType[]> => {
+  const response = await server_axiosInstance.get(`/api/admissions/status`);
   return response.data;
 };
 

--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -32,7 +32,7 @@ function Snackbar({ open, handleClose, autoHideDuration, message, position }: Sn
   if (!shouldRender) return null;
 
   return (
-    <div className={cn('absolute z-20 flex w-full justify-center', position === 'bottom' ? 'bottom-24' : 'top-5')}>
+    <div className={cn('absolute left-1/2 z-20 -translate-x-1/2', position === 'bottom' ? 'bottom-24' : 'top-5')}>
       <div
         onTransitionEnd={onTransitionEnd}
         className={cn(
@@ -41,7 +41,7 @@ function Snackbar({ open, handleClose, autoHideDuration, message, position }: Sn
         )}
       >
         <WarningIcon />
-        <span>{message}</span>
+        <span className="whitespace-nowrap">{message}</span>
       </div>
     </div>
   );

--- a/src/hooks/querys/useAdmissionStatus.ts
+++ b/src/hooks/querys/useAdmissionStatus.ts
@@ -1,0 +1,15 @@
+import { getAdmissionStatus } from '@/api/api';
+import formatAdmissionStatus from '@/utils/format-admission-status';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export default function useAdmissionStatus() {
+  const data = useSuspenseQuery({
+    queryKey: ['ADMISSION_STATUS'],
+    queryFn: getAdmissionStatus,
+    select: (data) => {
+      return formatAdmissionStatus(data);
+    },
+  });
+
+  return data;
+}

--- a/src/hooks/use-admission-status-message.ts
+++ b/src/hooks/use-admission-status-message.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { ADDMISSION, AdmissionType } from '@/types/admission-type';
+
+export default function useAdmissionStatusMessage(statuses: Record<AdmissionType, boolean>) {
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const activeCategories = Object.entries(statuses)
+      .filter(([, status]) => status)
+      .map(([admissionType]) => ADDMISSION[admissionType as AdmissionType]);
+
+    if (!activeCategories.length) {
+      setOpenSnackbar(true);
+      setMessage(`현재는 모든 카테고리 이용이 불가능해요`);
+    } else if (activeCategories.length && activeCategories.length !== 3) {
+      setOpenSnackbar(true);
+      setMessage(`현재는 ${activeCategories.join(',')} 카테고리만 이용 가능해요`);
+    }
+  }, [statuses]);
+
+  const closeSnackbar = () => {
+    setOpenSnackbar(false);
+  };
+
+  return { message, openSnackbar, closeSnackbar };
+}

--- a/src/hooks/use-animation.hooks.ts
+++ b/src/hooks/use-animation.hooks.ts
@@ -2,16 +2,27 @@ import { useEffect, useState } from 'react';
 
 export function useAnimation(condition: boolean) {
   const [isComplete, setIsComplete] = useState(false);
+  const [animationTrigger, setAnimationTrigger] = useState(false);
 
   useEffect(() => {
-    if (condition) setIsComplete(true);
+    if (condition) {
+      setIsComplete(true);
+
+      requestAnimationFrame(() => {
+        setAnimationTrigger(true);
+      });
+    } else {
+      setAnimationTrigger(false);
+    }
   }, [condition]);
 
   const onTransitionEnd = () => {
-    if (!condition) setIsComplete(false);
+    if (!condition) {
+      setIsComplete(false);
+    }
   };
+
   const shouldRender = condition || isComplete;
-  const animationTrigger = condition && isComplete;
 
   return {
     shouldRender,

--- a/src/page/components/chat-step/choose-admission/choose-admission.tsx
+++ b/src/page/components/chat-step/choose-admission/choose-admission.tsx
@@ -1,4 +1,7 @@
 import PresetButton from '@/components/preset-button/preset-button';
+import Snackbar from '@/components/snackbar/snackbar';
+import useAdmissionStatus from '@/hooks/querys/useAdmissionStatus';
+import useAdmissionStatusMessage from '@/hooks/use-admission-status-message';
 import useAdmissionStore from '@/stores/store/admission-store';
 import useMessagesStore from '@/stores/store/message-store';
 import { ADDMISSION, AdmissionType } from '@/types/admission-type';
@@ -11,7 +14,10 @@ interface Props {
 
 function ChooseAdmission({ changeStep }: Props) {
   const admissions: AdmissionType[] = ['SUSI', 'JEONGSI', 'PYEONIP'];
+  const { data: admissionStatus } = useAdmissionStatus();
   const { setAdmissionType } = useAdmissionStore();
+  const { message, openSnackbar, closeSnackbar } = useAdmissionStatusMessage(admissionStatus);
+
   const { setMessages } = useMessagesStore();
 
   const selectAdmission = (admission: AdmissionType) => {
@@ -27,16 +33,26 @@ function ChooseAdmission({ changeStep }: Props) {
   };
 
   return (
-    <div className="flex flex-col">
-      <div className="mt-2 flex w-full flex-col items-end gap-2">
-        {admissions.map((admission) => (
-          <PresetButton
-            key={admission}
-            onClick={() => selectAdmission(admission)}
-          >{`${ADDMISSION[admission]} 전형이 궁금해요`}</PresetButton>
-        ))}
+    <>
+      <div className="flex flex-col">
+        <div className="mt-2 flex w-full flex-col items-end gap-2">
+          {admissions.map((admission) => (
+            <PresetButton
+              key={admission}
+              onClick={() => selectAdmission(admission)}
+              disabled={!admissionStatus[admission]}
+            >{`${ADDMISSION[admission]} 전형이 궁금해요`}</PresetButton>
+          ))}
+        </div>
       </div>
-    </div>
+      <Snackbar
+        open={openSnackbar}
+        handleClose={closeSnackbar}
+        message={message}
+        position="top"
+        autoHideDuration={3000}
+      />
+    </>
   );
 }
 

--- a/src/page/components/main/main.tsx
+++ b/src/page/components/main/main.tsx
@@ -34,7 +34,11 @@ function Main() {
           <MessageHistory />
           <Funnel<ChatSteps> step={steps}>
             <Funnel.Step<ChatSteps> step="입시유형 선택">
-              <ChooseAdmission changeStep={changeStep} />
+              <APIErrorBoundary>
+                <Suspense>
+                  <ChooseAdmission changeStep={changeStep} />
+                </Suspense>
+              </APIErrorBoundary>
             </Funnel.Step>
             <Funnel.Step<ChatSteps> step="입시유형 상세전형 선택">
               <APIErrorBoundary>

--- a/src/types/admission-type.ts
+++ b/src/types/admission-type.ts
@@ -14,6 +14,6 @@ export interface ResponseDetailAdmissionType {
 }
 
 export interface isActiveAdmissionType {
-  admissionType: AdmissionType;
+  type: AdmissionType;
   isActivated: boolean;
 }

--- a/src/utils/format-admission-status.ts
+++ b/src/utils/format-admission-status.ts
@@ -1,0 +1,16 @@
+import { AdmissionType, isActiveAdmissionType } from '@/types/admission-type';
+
+function formatAdmissionStatus(data: isActiveAdmissionType[]) {
+  const statusObject: Record<AdmissionType, boolean> = {
+    SUSI: false,
+    JEONGSI: false,
+    PYEONIP: false,
+  };
+  for (const status of data) {
+    statusObject[status.type] = status.isActivated;
+  }
+
+  return statusObject;
+}
+
+export default formatAdmissionStatus;


### PR DESCRIPTION
## 📝 PR 내용

- 수시, 정시, 편입 카테고리 사용 가능 여부에 따라 버튼 활성화/비활성화 기능을 추가했습니다.

## ✅ 작업 내용

- 수시,정시, 편입 카테고리 api 추가했습니다
- 수시,정시,편입 카테고리 상태를 확인하는 커스텀 훅을 정의했습니다.
    - api 에서 반환하는 데이터 형식을 조금 더 사용하기 쉽게 포맷팅 하는 과정을 거쳤습니다. 5fdc8e07ff18659159bbec825ec8179b31ebdafd tanstack-query의 select 기능을 사용했습니다
    - `{SUSI:true,JEONSI:true,PYEONIP:true}` 와 같은 객체 형태로 변경했습니다.
- 모든 카테고리가 사용 가능한 경우에는 별도의 snack bar 메시지를 보여주지 않으며, 하나 이상의 카테고리만 사용 가능할 경우 + 전부 사용 불가능한 상태에서만 메시지를 보여줍니다.
    - 해당 구현부는 커스텀 훅으로 별도 분리했습니다 64255ccf7b14cd4e7ea2db1394d6210fabeadb67

## 📸 스크린 샷 / 영상 (선택)
![chrome_qgN1gk4S7L](https://github.com/user-attachments/assets/9c20a303-26ee-433f-9bfb-0250d0299e12)


## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #25