### PR TITLE
[FEAT-37] 컴포넌트의 로딩을 의도적으로 지연하는 withDeferred 컴포넌트 구현

### DIFF
--- a/src/components/drggable-scroller/draggable-scroller.tsx
+++ b/src/components/drggable-scroller/draggable-scroller.tsx
@@ -8,7 +8,7 @@ function DraggableScroller({ children }: { children: React.ReactNode }) {
   return (
     <div
       ref={scrollRef}
-      className="scrollbar flex w-80 cursor-grab select-none flex-nowrap items-start gap-5 overflow-x-auto"
+      className="scrollbar -mr-3 flex w-full cursor-grab select-none flex-nowrap items-start gap-5 overflow-x-auto"
       {...events}
     >
       {children}

--- a/src/components/drggable-scroller/draggable-scroller.tsx
+++ b/src/components/drggable-scroller/draggable-scroller.tsx
@@ -8,7 +8,7 @@ function DraggableScroller({ children }: { children: React.ReactNode }) {
   return (
     <div
       ref={scrollRef}
-      className="scrollbar -mr-3 flex w-full cursor-grab select-none flex-nowrap items-start gap-5 overflow-x-auto"
+      className="scrollbar flex w-full cursor-grab select-none flex-nowrap items-start gap-5 overflow-x-auto"
       {...events}
     >
       {children}

--- a/src/components/header/bottom-sheet/contact.tsx
+++ b/src/components/header/bottom-sheet/contact.tsx
@@ -5,7 +5,7 @@ interface ContactItemProps {
 }
 function ContactItem({ title, department, numbers }: ContactItemProps) {
   return (
-    <div className="flex text-label text-gray-500">
+    <div className="flex text-label text-[#888891]">
       <span className="w-1/2">{title}</span>
       <span className="flex-1 whitespace-nowrap">
         {department} :{' '}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -14,7 +14,7 @@ function Header() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 h-16 w-full bg-white">
+      <header className="sticky top-0 z-10 h-16 w-full border-b border-b-[#D7D7DA] bg-white">
         <div className="flex h-full items-center justify-between px-4">
           <IconButton aria-label="새로고침" onClick={() => window.location.reload()}>
             <ReloadIcon />
@@ -23,15 +23,15 @@ function Header() {
             <h1 className="text-center text-headline text-primary">명지대 입학처 챗봇</h1>
             {admissionType && <Chip label={CHIP_LABEL[admissionType]} />}
           </div>
-          <IconButton aria-label="메뉴" onClick={onOpen}>
-            <HamburgerIcon />
+          <IconButton aria-label="메뉴" onClick={onOpen} className="h-5 w-5">
+            <HamburgerIcon className="w-full" />
           </IconButton>
         </div>
       </header>
       <BottomSheet open={open} onClose={onClose}>
         <div className="flex h-full w-full flex-col justify-between gap-3">
-          <IconButton onClick={onClose} className="absolute right-10 top-10" aria-label="닫기 버튼">
-            <CloseIcon />
+          <IconButton onClick={onClose} className="absolute right-3 top-10 h-6 w-6" aria-label="닫기 버튼">
+            <CloseIcon className="w-full" />
           </IconButton>
           <AdmissionQuickLinkTabs initialAdmissionType={admissionType} />
           <Contact />

--- a/src/components/hoc/with-deferred.tsx
+++ b/src/components/hoc/with-deferred.tsx
@@ -1,0 +1,20 @@
+import { ComponentType, useEffect, useState } from 'react';
+
+function withDeferred<P extends object>(WrappedComponent: ComponentType<P>) {
+  return function DeferredComponent(props: P) {
+    const [isDeferred, setIsDeferred] = useState(false);
+
+    useEffect(() => {
+      const timeoutId = setTimeout(() => {
+        setIsDeferred(true);
+      }, 200);
+      return () => clearTimeout(timeoutId);
+    }, []);
+
+    if (!isDeferred) return;
+
+    return <WrappedComponent {...props} />;
+  };
+}
+
+export default withDeferred;

--- a/src/components/loading/chat-loading-spinner.tsx
+++ b/src/components/loading/chat-loading-spinner.tsx
@@ -1,8 +1,9 @@
 import ChatLoadingAnimation from '@/assets/lottie/chat-loading.json';
 import { MaruIcon } from '@/assets/svg';
+import withDeferred from '@/components/hoc/with-deferred';
 import Lottie from 'lottie-react';
 
-function ChatLoadingSpinner() {
+function LoadingSpinner() {
   return (
     <div className="relative flex">
       <MaruIcon className="absolute -left-9 top-6" />
@@ -14,4 +15,5 @@ function ChatLoadingSpinner() {
   );
 }
 
+const ChatLoadingSpinner = withDeferred(LoadingSpinner);
 export default ChatLoadingSpinner;

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import MenuListTitle from '@/components/menu-list/menu-list-title';
 
 function MenuList({ children }: { children: React.ReactNode }) {
-  return <div className="w-56 min-w-56 divide-y rounded-lg border border-category_border bg-white">{children}</div>;
+  return (
+    <div className="flex w-56 min-w-56 flex-col divide-y divide-[#D7D7DA] rounded-lg border border-category_border bg-white">
+      {children}
+    </div>
+  );
 }
 
 MenuList.Title = MenuListTitle;

--- a/src/page/components/chat-step/choose-admission/steps/choose-admission-category.tsx
+++ b/src/page/components/chat-step/choose-admission/steps/choose-admission-category.tsx
@@ -48,7 +48,7 @@ function ChooseAdmissionCategory({ admissionType, changeAdmissionStep }: Props) 
 
   return (
     <div>
-      <div className="mt-2">
+      <div className="-mr-3 mt-2">
         <DraggableScroller>
           {data.map((option) => (
             <MenuList key={option.label}>

--- a/src/page/components/preset-buttons/preset-buttons.tsx
+++ b/src/page/components/preset-buttons/preset-buttons.tsx
@@ -48,7 +48,7 @@ function PresetButtons({ changeStep, handleQuestionSelect, showReferenceButton =
   return (
     <div>
       <div className="mt-5 flex w-full justify-end">
-        <div className="flex w-72 flex-wrap justify-end gap-2">
+        <div className="flex w-64 flex-wrap justify-end gap-2">
           {showReferenceButton && (
             <PresetButton onClick={handleReferenceButtonClick}>🙋‍♂️ 어디에서 볼 수 있나요?</PresetButton>
           )}

--- a/src/page/components/question-form/question-form.tsx
+++ b/src/page/components/question-form/question-form.tsx
@@ -10,10 +10,10 @@ function QuestionForm({ changeStep }: QuestionFormProps) {
   const { content, isLoading, setContent, handleSubmit } = useQuestionForm({ changeStep });
 
   return (
-    <div className="absolute bottom-0 h-20 w-full bg-white px-2">
-      <form className="flex h-20" onSubmit={handleSubmit}>
+    <div className="absolute bottom-0 h-20 w-full border-t border-category_border bg-white px-2">
+      <form className="flex h-20 justify-between" onSubmit={handleSubmit}>
         <input
-          className={`h-11 w-80 bg-white ${isLoading && 'cursor-progress'} focus:outline-none`}
+          className={`h-11 w-80 bg-white pl-3 ${isLoading && 'cursor-progress'} focus:outline-none`}
           placeholder={'질문을 입력해주세요'}
           value={content}
           onChange={(e) => setContent(e.target.value)}
@@ -21,7 +21,7 @@ function QuestionForm({ changeStep }: QuestionFormProps) {
         />
         <button
           type="submit"
-          className={`${isLoading && 'cursor-progress'} flex h-11 w-11 items-center justify-center`}
+          className={`${isLoading && 'cursor-progress'} flex h-11 w-11 items-center justify-center pl-4`}
           disabled={isLoading || !content}
         >
           <SendIcon />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
           DEFAULT: '#002968',
           egg: 'rgba(0, 41, 104, 0.06)',
         },
-        category_border: '#EBEBEB',
+        category_border: '#D7D7DA',
       },
       screens: {
         mobile: '360px',


### PR DESCRIPTION
## 📝 PR 내용
- API 호출 시간이 매우 짧아도 로딩 인디케이터가 노출되는 것이 부자연스러워 의도적으로 컴포넌트의 렌더링을 지연시키는 컴포넌트를 개발했습니다.

## ✅ 작업 내용
- hoc 패턴을 통해 개발했습니다. 
  - 처음 `DeferredComponent` 를 일반적인 컴포넌트 형태로 개발했으나 `Suspense`에 존재하는 `ChatLoadingSpinner` 컴포넌트를 모두` DeferredComponent`로 감싸줘야 하는 대규모 수정이 일어나기에 `ChatLoadingSpinner` 자체를 `hoc`로 감싸서 반환하는게 효율적이라 생각해 `hoc` 패턴으로 노선을 변경했습니다.
 ```  
// 초기 구현시 아래와 같이 적용해야 했음
      <Suspense fallback={<ChatLoadingSpinner />}>
        <DeferredComponent>
          <ChooseAdmission changeAdmissionStep={changeAdmissionStep} />
        </DeferredComponent>
      </Suspense>
//  개발 후 Suspense에 존재하는 LoadingSpinner를 모두 변경하는것은 비효율적이라 생각해 고차컴포넌트 형태로 변경
const ChatLoadingSpinner = withDeferred(LoadingSpinner);
export default ChatLoadingSpinner;
```
- 지연 렌더링은 setTimeout을 통해 개발했으며 시간 기준은 200ms 로 정의했습니다.


## 📸 스크린 샷 / 영상 (선택)
변경 전
![chrome_5o7vFn0wSe](https://github.com/user-attachments/assets/09f921c1-281d-4172-b972-db1f3c1395b1) 
변경 후
![chrome_tUSaGJVdct](https://github.com/user-attachments/assets/d19614c5-483f-4931-aaf8-a5e4b515f52b)


## 🤔 고민 했던 부분 (선택)
개인적으로 지연 시간 기준을 200ms 로 잡았는데 적절하다고 생각하시나용?

## 🔗 연관 이슈
- Closes #38 
